### PR TITLE
Local image fix

### DIFF
--- a/Engine/Engine.csproj
+++ b/Engine/Engine.csproj
@@ -1,7 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
+	<UseWPF>true</UseWPF>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -23,7 +24,9 @@
     <Resource Include="Images\Locations\Farmhouse.png" />
     <Resource Include="Images\Locations\HerbalistsGarden.png" />
     <Resource Include="Images\Locations\HerbalistsHut.png" />
-    <Resource Include="Images\Locations\Home.png" />
+    <Resource Include="Images\Locations\Home.png">
+      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
+    </Resource>
     <Resource Include="Images\Locations\SpiderForest.png" />
     <Resource Include="Images\Locations\TownGate.png" />
     <Resource Include="Images\Locations\TownSquare.png" />

--- a/Engine/Engine.csproj
+++ b/Engine/Engine.csproj
@@ -24,9 +24,6 @@
     <Resource Include="Images\Locations\Farmhouse.png" />
     <Resource Include="Images\Locations\HerbalistsGarden.png" />
     <Resource Include="Images\Locations\HerbalistsHut.png" />
-    <Resource Include="Images\Locations\Home.png">
-      <CopyToOutputDirectory>Never</CopyToOutputDirectory>
-    </Resource>
     <Resource Include="Images\Locations\SpiderForest.png" />
     <Resource Include="Images\Locations\TownGate.png" />
     <Resource Include="Images\Locations\TownSquare.png" />

--- a/WPFUI/WPFUI.csproj
+++ b/WPFUI/WPFUI.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>


### PR DESCRIPTION
# Objective
Resolve issue #1.

## Solution
Changed the project SDKs from Microsoft.NET.Sdk to Microsoft.NET.Sdk.WindowsDesktop. Also, set the target framework of Engine.csproj to net6.0-windows (instead of .net6.0).

Microsoft.NET.Sdk.WindowsDesktop includes the necessary features to support WPF applications, allowing the local path usage in GameSession.cs to work correctly as implemented.
